### PR TITLE
Document deprecations and clean up testing/CI code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 install: composer install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 # Travis CI Configuration File
 
+branches:
+  only:
+    - main
+
 # Tell Travis CI we're using PHP
 language: php
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - **New**: Introduce new `Asset_Loader\register_asset()` and `Asset_Loader\enqueue_asset()` public API.
   - Assets should now be registered individually.
   - If a bundle exports both a CSS and JS file, both files should be registered or enqueued individually.
+- **Deprecate** `Asset_Loader\autoenqueue()` method. Use the new, singular `register_asset()` or `enqueue_asset()` instead.
+- **Deprecate** `Asset_Loader\autoregister()` method. Use the new, singular `register_asset()` or `enqueue_asset()` instead.
+- **Deprecate** `Asset_Loader\register_assets()` method. Use the new, singular `register_asset()` or `enqueue_asset()` instead.
 - Refactor how SSL warning notice behavior gets triggered during asset registration.
 - Change how version strings are determined when registering assets
   - If asset is detected to be using a uniquely hashed filename, no version string is used.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -10,6 +10,7 @@ namespace Asset_Loader;
 /**
  * Register some or all scripts and styles defined in a manifest file.
  *
+ * @deprecated 0.4.0
  * @param string $manifest_path Absolute path to a Webpack asset manifest file.
  * @param array  $options {
  *     @type array    $scripts Script dependencies.
@@ -20,6 +21,14 @@ namespace Asset_Loader;
  * @return array|null An array of registered script and style handles, or null.
  */
 function register_assets( $manifest_path, $options = [] ) {
+	if ( function_exists( '_doing_it_wrong' ) ) {
+		_doing_it_wrong(
+			'register_assets',
+			'register_assets() is deprecated and will be removed soon. Use register_asset() instead.',
+			'0.4.0'
+		);
+	}
+
 	$defaults = [
 		'handle'  => basename( plugin_dir_path( $manifest_path ) ),
 		'filter'  => '__return_true',
@@ -108,6 +117,7 @@ function register_assets( $manifest_path, $options = [] ) {
  *
  * The manifest, build_path, and target_bundle options are required.
  *
+ * @deprecated 0.4.0
  * @param string $manifest_path Absolute file system path to Webpack asset manifest file.
  * @param string $target_bundle The expected string filename of the bundle to load from the manifest.
  * @param array  $options {
@@ -209,6 +219,7 @@ function autoregister( string $manifest_path, string $target_bundle, array $opti
  *
  * The manifest, build_path, and target_bundle options are required.
  *
+ * @deprecated 0.4.0
  * @param string $manifest_path Absolute file system path to Webpack asset manifest file.
  * @param string $target_bundle The expected string filename of the bundle to load from the manifest.
  * @param array  $options {

--- a/tests/class-mock-asset-registry.php
+++ b/tests/class-mock-asset-registry.php
@@ -23,13 +23,6 @@ class Mock_Asset_Registry {
 	public $enqueued;
 
 	public function __construct() {
-		$this->reset();
-	}
-
-	/**
-	 * Clean out the arrays of registered or enqueued assets.
-	 */
-	public function reset() : void {
 		$this->registered = [];
 		$this->enqueued = [];
 	}


### PR DESCRIPTION
- Fully deprecate prior generation of enqueuing functions
- Do not run branch-level builds for PR branches to save time and concurrency in Travis
- Remove unneeded code in mock asset registry that had been flagged in #22
- Test in PHP 7.4