### PR TITLE
Allow the option to enqueue script in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ To register an asset to be manually enqueued later, use `Asset_Loader\register_a
 
 If a manifest is not present then `Asset_Loader` will attempt to load the specified resource from the same directory containing the manifest file.
 
+By default, all enqueues will be added at the end of the page, in the `wp_footer` action. If you need your script to be enqueued in the document `<head>`, pass the flag `'in-footer' => false,` within the options array.
+
 ## Local Development
 
 Before submitting a pull request, ensure that your PHP code passes all existing unit tests and conforms to our [coding standards](https://github.com/humanmade/coding-standards) by running these commands:

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -34,7 +34,6 @@ function register_assets( $manifest_path, $options = [] ) {
 		'filter'  => '__return_true',
 		'scripts' => [],
 		'styles'  => [],
-		'in-footer' => true,
 	];
 
 	$options = wp_parse_args( $options, $defaults );
@@ -80,7 +79,7 @@ function register_assets( $manifest_path, $options = [] ) {
 				$asset_uri,
 				$options['scripts'],
 				$manifest_hash,
-				$options['in-footer']
+				true
 			);
 			$registered['scripts'][] = $options['handle'];
 		} elseif ( $is_css ) {
@@ -150,7 +149,6 @@ function autoregister( string $manifest_path, string $target_bundle, array $opti
 		'filter'     => '__return_true',
 		'scripts'    => [],
 		'styles'     => [],
-		'in-footer'  => true,
 	];
 
 	$options = wp_parse_args( $options, $defaults );
@@ -194,7 +192,7 @@ function autoregister( string $manifest_path, string $target_bundle, array $opti
 			Paths\get_file_uri( $js_bundle ),
 			$options['scripts'],
 			md5_file( $js_bundle ),
-			$options['in-footer']
+			true
 		);
 		$registered['scripts'][] = $options['handle'];
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -165,7 +165,6 @@ function autoregister( string $manifest_path, string $target_bundle, array $opti
 			},
 		'scripts' => $options['scripts'],
 		'styles'  => $options['styles'],
-		'in-footer' => $options['in-footer'],
 	] );
 
 	$build_path = trailingslashit( $options['build_path'] );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -34,6 +34,7 @@ function register_assets( $manifest_path, $options = [] ) {
 		'filter'  => '__return_true',
 		'scripts' => [],
 		'styles'  => [],
+		'in-footer' => true,
 	];
 
 	$options = wp_parse_args( $options, $defaults );
@@ -79,7 +80,7 @@ function register_assets( $manifest_path, $options = [] ) {
 				$asset_uri,
 				$options['scripts'],
 				$manifest_hash,
-				true
+				$options['in-footer']
 			);
 			$registered['scripts'][] = $options['handle'];
 		} elseif ( $is_css ) {
@@ -149,6 +150,7 @@ function autoregister( string $manifest_path, string $target_bundle, array $opti
 		'filter'     => '__return_true',
 		'scripts'    => [],
 		'styles'     => [],
+		'in-footer'  => true,
 	];
 
 	$options = wp_parse_args( $options, $defaults );
@@ -165,6 +167,7 @@ function autoregister( string $manifest_path, string $target_bundle, array $opti
 			},
 		'scripts' => $options['scripts'],
 		'styles'  => $options['styles'],
+		'in-footer' => $options['in-footer'],
 	] );
 
 	$build_path = trailingslashit( $options['build_path'] );
@@ -191,7 +194,7 @@ function autoregister( string $manifest_path, string $target_bundle, array $opti
 			Paths\get_file_uri( $js_bundle ),
 			$options['scripts'],
 			md5_file( $js_bundle ),
-			true
+			$options['in-footer']
 		);
 		$registered['scripts'][] = $options['handle'];
 	}
@@ -318,6 +321,7 @@ function _register_or_update_script( string $handle, string $asset_uri, array $d
 function register_asset( string $manifest_path, string $target_asset, array $options = [] ) : array {
 	$defaults = [
 		'dependencies' => [],
+		'in-footer' => true,
 	];
 	$options = wp_parse_args( $options, $defaults );
 
@@ -396,7 +400,7 @@ function register_asset( string $manifest_path, string $target_asset, array $opt
 			$asset_uri,
 			$options['dependencies'],
 			$asset_version,
-			true
+			$options['in-footer']
 		);
 		$handles['script'] = $asset_handle;
 	}


### PR DESCRIPTION
Continue to default the enqueue to be in the footer. In order to enqueue the script within the header, pass the following within the $options array.
```
'in-footer' => false
```