### PR TITLE
Remove prescriptive editorconfig width for tab indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,6 @@ trim_trailing_whitespace = true
 charset = utf-8
 # Tab indentation
 indent_style = tab
-tab_width = 2
 
 # Use 4-space indentation on composer.json
 [{composer.json}]


### PR DESCRIPTION
There are accessibility (and dev happiness) benefits to leaving tab width unspecified in editorconfig. From the docs:

> It is acceptable and often preferred to leave certain EditorConfig properties unspecified. For example, tab_width need not be specified unless it differs from the value of indent_size. Also, when indent_style is set to tab, it may be desirable to leave indent_size unspecified so readers may view the file using their preferred indentation width.

h/t @ntwb 