### PR TITLE
Make manifest content filterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - **Breaking**: Remove deprecated `autoregister`, `autoenqueue`, and `register_assets` methods.
+- Add filter `asset_loader_manifest_contents` to allow filtering of loaded asset manifest contents.
 
 ## v0.5.0
 

--- a/inc/manifest.php
+++ b/inc/manifest.php
@@ -51,7 +51,7 @@ function load_asset_manifest( $path ) {
 		return null;
 	}
 
-	$manifests[ $path ] = json_decode( $contents, true );
+	$manifests[ $path ] = apply_filters( 'asset_loader_manifest_contents', json_decode( $contents, true ), $path );
 
 	return $manifests[ $path ];
 }

--- a/inc/manifest.php
+++ b/inc/manifest.php
@@ -51,6 +51,14 @@ function load_asset_manifest( $path ) {
 		return null;
 	}
 
+	/**
+	 * Filter the contents of the loaded manifest.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param array $contents The loaded manifest contents.
+	 * @param string $path The path to the JSON file loaded.
+	 */
 	$manifests[ $path ] = apply_filters( 'asset_loader_manifest_contents', json_decode( $contents, true ), $path );
 
 	return $manifests[ $path ];

--- a/inc/manifest.php
+++ b/inc/manifest.php
@@ -56,8 +56,8 @@ function load_asset_manifest( $path ) {
 	 *
 	 * @since 0.6.0
 	 *
-	 * @param array $contents The loaded manifest contents.
-	 * @param string $path The path to the JSON file loaded.
+	 * @param array  $contents The loaded manifest contents.
+	 * @param string $path     The path to the JSON file loaded.
 	 */
 	$manifests[ $path ] = apply_filters( 'asset_loader_manifest_contents', json_decode( $contents, true ), $path );
 


### PR DESCRIPTION
This PR adds a filter (`'asset_loader_manifest_contents`) to `load_asset_manifest`, which allows manipulation of a loaded json file (e.g remove entries, change file paths, remove nesting).

This fixes a project issue I'm having where a 3rd party React app generates a manifest file which looks like this:

```json
{
  "files": {
    "lorem.css": "/static/css/lorem.some_hash.chunk.css",
    "ipsum.js": "/static/js/ipsum.some_other_hash.chunk.js"
  },
  "entrypoints": [
    "static/css/lorem.some_hash.chunk.css",
    "static/js/ipsum.some_other_hash.chunk.js"
  ]
}
```

instead of the expected:

```json
{
  "lorem.css": "static/css/lorem.some_hash.chunk.css",
  "ipsum.js": "static/js/ipsum.some_other_hash.chunk.js"
}
```

Example usage:

```php

add_filter( 'asset_loader_manifest_contents', function( $manifest, $path ) {
		if ( $path === 'something/a_particular_manifest.json' ) {
		  return do_something_interesting( $manifest );
		}
		return $manifest;
	}, 10, 2 );

```