### PR TITLE
Register runtime as dependency if found

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -107,6 +107,15 @@ function register_asset( string $manifest_path, string $target_asset, array $opt
 	$asset_handle = $options['handle'] ?? $target_asset;
 	$asset_version = Manifest\get_version( $asset_uri, $manifest_path );
 
+	// If running the development build with runtimeChunk: single, a runtime file will be present in the manifest.
+	// Register this and ensure it is loaded only once per page.
+	$runtime = Manifest\get_manifest_resource( $manifest_path, 'runtime.js' );
+	if ( $runtime ) {
+		$runtime_handle = 'runtime-' . hash( 'crc32', $runtime ); // Ensure unique handle based on src.
+		wp_register_script( $runtime_handle, $runtime );
+		$options['dependencies'][] = $runtime_handle;
+	}
+
 	// Track registered handles so we can enqueue the correct assets later.
 	$handles = [];
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -120,6 +120,14 @@ function register_asset( string $manifest_path, string $target_asset, array $opt
 	$handles = [];
 
 	if ( is_css( $asset_uri ) ) {
+		// Don't set runtime JS as dependency of a CSS file.
+		if ( isset( $runtime_handle ) ) {
+			$key = array_search( $runtime_handle, $options['dependencies'] );
+			if ( $key !== false ) {
+				unset( $options['dependencies'][ $key ] );
+			}
+		}
+
 		// Register a normal CSS bundle.
 		wp_register_style(
 			$asset_handle,


### PR DESCRIPTION
Something we have faced when updating [`@humanmade/webpack-helpers` to Webpack v5](https://github.com/humanmade/webpack-helpers/pull/205#issuecomment-1211894225) is that hot reloading does not work correctly when you have multiple JS files emitted by a single webpack configuration and loaded on a page at the same time. 

The issue is caused by the fact that each file emitted has the webpack runtime included. The fix for this is to split that into a separate file by setting `optimization: { runtimeChunk: 'single' }` in your webpack dev config. This spits out a new JS file `runtime.js` that needs to be loaded once per page. 

What does this PR do? It detects if `runtime.js` is present in the manifest, and if so it registers that script and sets it as a dependency of the asset being loaded. This ensures it is always loaded, but only once, on the page