### PR TITLE
Update to Jekyll 4, inherit from theme

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v2
+      - name: Bundle install
+        run: |
+          bundle install --path=vendor/bundle --jobs 4 --retry 3
+          bundle clean
       - name: Build with Jekyll
         run: |
           cd docs

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
-gem "webrick", "~> 1.7"
-gem "just-the-hm-docs", ">= 1.0.1.rc1"
+gem "jekyll", "~> 4.3.2"
+gem "webrick", "~> 1.8"
+gem "just-the-hm-docs", github: "humanmade/just-the-hm-docs"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/humanmade/just-the-hm-docs.git
+  revision: 07115607c8d441811d1fc49de89c2591d4029785
+  specs:
+    just-the-hm-docs (1.0.2.rc1)
+      jekyll (>= 4.3.2)
+      jekyll-seo-tag (>= 2.0)
+      rake (>= 12.3.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -38,10 +47,6 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    just-the-hm-docs (1.0.1.rc1)
-      jekyll (>= 3.8.5)
-      jekyll-seo-tag (>= 2.0)
-      rake (>= 12.3.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -75,8 +80,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  just-the-hm-docs (>= 1.0.1.rc1)
-  webrick (~> 1.7)
+  jekyll (~> 4.3.2)
+  just-the-hm-docs!
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.3.5

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,16 +20,8 @@ author: Human Made
 baseurl: '/asset-loader' # the subpath of your site, e.g. /blog
 url: 'https://humanmade.github.io' # the base hostname & protocol for your site, e.g. http://example.com
 
-# Set a path/url to a logo that will be displayed instead of the title
-logo: "/assets/icons/hm-logo.svg"
-
-# Set a path/url to a favicon that will be displayed by the browser
-favicon_ico: "/assets/favicon/favicon.ico"
-
 # Theme settings
 theme: just-the-hm-docs
-color_scheme: hm
-permalink: pretty
 
 aux_links:
   "Asset Loader on GitHub":
@@ -40,21 +32,3 @@ nav_external_links:
     url: https://github.com/humanmade/asset-loader
   - title: Issues
     url: https://github.com/humanmade/asset-loader/issues
-
-callouts_level: quiet # or loud
-callouts_opacity: 0.3
-callouts:
-  highlight:
-    color: yellow
-  important:
-    title: Important
-    color: hm-purple-callout
-  new:
-    title: New
-    color: hm-mint-callout
-  note:
-    title: Note
-    color: hm-blue-callout
-  warning:
-    title: Warning
-    color: hm-red-callout


### PR DESCRIPTION
We updated Just the HM Docs to Jekyll 4 in https://github.com/humanmade/just-the-hm-docs/pull/11 so that we could inherit site variables from the theme config.

This PR makes those updates to the gemfile and config, and adds a necessary bundle install step to the deploy action.