### PR TITLE
Allow for registering scripts within block.json to be handled with asset loader

### DIFF
--- a/asset-loader.php
+++ b/asset-loader.php
@@ -36,6 +36,7 @@ if ( defined( __NAMESPACE__ . '\\LOADED' ) ) {
 const LOADED = true;
 
 require plugin_dir_path( __FILE__ ) . 'inc/admin.php';
+require plugin_dir_path( __FILE__ ) . 'inc/blocks.php';
 require plugin_dir_path( __FILE__ ) . 'inc/manifest.php';
 require plugin_dir_path( __FILE__ ) . 'inc/paths.php';
 require plugin_dir_path( __FILE__ ) . 'inc/namespace.php';

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Define functions for registering a block from metadata with asset-loader.
+ */
+
+declare( strict_types=1 );
+
+namespace Asset_Loader\Blocks;
+
+use WP_Block_Type;
+
+/**
+ * Get list of keys in block.json which should be filtered to load from a manifest.
+ *
+ * @return string[] An array of keys for block.json
+ */
+function get_asset_keys() : array {
+
+	$asset_keys = [
+		'editorScript',
+		'script',
+		'viewScript',
+		'editorStyle',
+
+	];
+
+	return apply_filters( 'asset_loader_block_asset_keys', $asset_keys );
+}
+
+function register_block_type_with_manifests( string|WP_Block_Type $block_type, array $args = [] ) {
+
+	// Early return if we are not using block.json.
+	if ( ! is_string( $block_type ) ) {
+		return \register_block_type( $block_type, $args );
+	}
+
+	add_filter( 'block_type_metadata', __NAMESPACE__ . '\\filter_block_metadata_scripts', 10, 1 );
+
+	$block = \register_block_type( $block_type, $args );
+
+	remove_filter( 'block_type_metadata', __NAMESPACE__ . '\\filter_block_metadata_scripts' );
+
+	return $block;
+}
+
+function filter_block_metadata_scripts( $metadata ) {
+	$asset_keys = get_asset_keys();
+}


### PR DESCRIPTION
Still very early WIP, but tracked here for visibility.

Create a new function `register_block_type_with_manifests()` as a wrapper for `register_block_type()`, which will filter the data from block.json to load included scripts and styles (e.g. `script`, `editorScript`) from a manifest file without having to register them separately.