### PR TITLE
Security enhancements: specific commit to 3rd-party GH Actions, secure `href` attr on 404.html file

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
         with:
           working-directory: ./docs
           ruby-version: '3.1'
-          bundler-cache: true 
+          bundler-cache: true
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v2

--- a/docs/404.html
+++ b/docs/404.html
@@ -8,4 +8,4 @@ search_exclude: true
 
 <h1>Page not found</h1>
 
-<p>The page you requested could not be found. Try using the navigation {% if site.search_enabled != false %}or search {% endif %}to find what you're looking for or go to this <a href="{{ '/' | relative_url }}">site's home page</a>.</p>
+<p>The page you requested could not be found. Try using the navigation {% if site.search_enabled != false %}or search {% endif %}to find what you're looking for or go to this <a href="{{ '/' | absolute_url | escape }}">site's home page</a>.</p>


### PR DESCRIPTION
This PR intends to add security enhancements:
- Point to specific commit for 3rd-party Github action
- Secure `href` attribute in 404 page to prevent XSS vulnerabilities: replaced `relative_url` with `absolute_url` to generate a full URL, which is less potential to manipulation, add escape filter to preventing potential XSS attacks.