### PR TITLE
#57: Do not fatal if empty/null manifest is passed to registration functions

### DIFF
--- a/inc/manifest.php
+++ b/inc/manifest.php
@@ -43,7 +43,7 @@ function load_asset_manifest( $path ) {
 		return $manifests[ $path ];
 	}
 
-	if ( ! is_readable( $path ) ) {
+	if ( empty( $path ) || ! is_readable( $path ) ) {
 		return null;
 	}
 	$contents = file_get_contents( $path );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -59,15 +59,20 @@ function _register_or_update_script( string $handle, string $asset_uri, array $d
 /**
  * Attempt to register a particular script bundle from a manifest.
  *
- * @param string $manifest_path File system path for an asset manifest JSON file.
- * @param string $target_asset  Asset to retrieve within the specified manifest.
- * @param array  $options {
+ * @param ?string $manifest_path File system path for an asset manifest JSON file.
+ * @param string  $target_asset  Asset to retrieve within the specified manifest.
+ * @param array   $options {
  *     @type string $handle       Handle to use when enqueuing the asset. Optional.
  *     @type array  $dependencies Script or Style dependencies. Optional.
  * }
  * @return array Array detailing which script and/or style handles got registered.
  */
-function register_asset( string $manifest_path, string $target_asset, array $options = [] ) : array {
+function register_asset( ?string $manifest_path, string $target_asset, array $options = [] ) : array {
+	if ( empty( $manifest_path ) ) {
+		trigger_error( "No manifest specified when loading $target_asset", E_USER_NOTICE );
+		return [];
+	}
+
 	$defaults = [
 		'dependencies' => [],
 		'in-footer' => true,
@@ -160,14 +165,14 @@ function register_asset( string $manifest_path, string $target_asset, array $opt
 /**
  * Register and immediately enqueue a particular asset within a manifest.
  *
- * @param string $manifest_path File system path for an asset manifest JSON file.
- * @param string $target_asset  Asset to retrieve within the specified manifest.
- * @param array  $options {
+ * @param ?string $manifest_path File system path for an asset manifest JSON file.
+ * @param string  $target_asset  Asset to retrieve within the specified manifest.
+ * @param array   $options {
  *     @type string $handle       Handle to use when enqueuing the asset. Optional.
  *     @type array  $dependencies Script or Style dependencies. Optional.
  * }
  */
-function enqueue_asset( string $manifest_path, string $target_asset, array $options = [] ) : void {
+function enqueue_asset( ?string $manifest_path, string $target_asset, array $options = [] ) : void {
 	$registered_handles = register_asset( $manifest_path, $target_asset, $options );
 
 	if ( isset( $registered_handles['script'] ) ) {


### PR DESCRIPTION
For #57 

Currently, if a theme implements the common pattern of using its own system to identify the manifest to use, and no matching manifest is found, the theme sometimes passes `null` to the registration or manifest loader functions. In both cases this caused a TypeError, since functions like `is_readable` cannot accept a `null` argument.

This patch guards against these errors by catching a missing manifest, and logs a notice instead indicating the theme or plugin call that corresponds to the missing file. This is a much more reliable way to indicate a rebuild is needed, and (among other things) makes it possible to bisect back and forth through theme code while tracing non-asset-related errors without having to make a time-consuming rebuild on each step.