### PR TITLE
Deprecate register_asset and enqueue_asset, renamed to ..._manifest_...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.8.0
+
+- Deprecate `register_asset` and `enqueue_asset` functions, renamed to `register_manifest_asset` and `enqueue_manifest_asset` respectively.
+
 ## v0.7.1
 
 - Fix invalid `sprintf` string token in manifest loading error message so that a missing manifest does not cause a fatal.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin exposes functions which may be used within other WordPress themes or
 
 This library is designed to work in conjunction with a Webpack configuration (such as those created with the presets in [@humanmade/webpack-helpers](https://github.com/humanmade/webpack-helpers)) which generate an asset manifest file. This manifest associates asset bundle names with either URIs pointing to asset bundles on a running DevServer instance, or else local file paths on disk.
 
-`Asset_Loader` provides a set of methods for reading in this manifest file and registering a specific resource within it to load within your WordPress website. The primary public interface provided by this plugin is a pair of methods, `Asset_Loader\register_asset()` and `Asset_Loader\enqueue_asset()`. To register a manifest asset call one of these methods inside actions like `wp_enqueue_scripts` or `enqueue_block_editor_assets`, in the same manner you would have called the standard WordPress `wp_register_script` or `wp_enqueue_style` functions.
+`Asset_Loader` provides a set of methods for reading in this manifest file and registering a specific resource within it to load within your WordPress website. The primary public interface provided by this plugin is a pair of methods, `Asset_Loader\register_manifest_asset()` and `Asset_Loader\enqueue_manifest_asset()`. To register a manifest asset call one of these methods inside actions like `wp_enqueue_scripts` or `enqueue_block_editor_assets`, in the same manner you would have called the standard WordPress `wp_register_script` or `wp_enqueue_style` functions.
 
 ```php
 <?php
@@ -24,7 +24,7 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_edit
  * @return void
  */
 function enqueue_block_editor_assets() {
-  Asset_Loader\enqueue_asset(
+  Asset_Loader\enqueue_manifest_asset(
     // In a plugin, this would be `plugin_dir_path( __FILE__ )` or similar.
     get_stylesheet_directory() . '/build/asset-manifest.json',
     // The handle of a resource within the manifest. For static file fallbacks,
@@ -36,7 +36,7 @@ function enqueue_block_editor_assets() {
     ]
   );
 
-  Asset_Loader\enqueue_asset(
+  Asset_Loader\enqueue_manifest_asset(
     // In a plugin, this would be `plugin_dir_path( __FILE__ )` or similar.
     get_stylesheet_directory() . '/build/asset-manifest.json',
     // Enqueue CSS for the editor.

--- a/docs/02-usage.md
+++ b/docs/02-usage.md
@@ -7,11 +7,11 @@ permalink: /usage
 
 # Usage
 
-This library is designed to work in conjunction with a Webpack configuration (such as those created with the presets in [@humanmade/webpack-helpers](https://github.com/humanmade/webpack-helpers)) which generate an asset manifest file. This manifest associates asset bundle names with either URIs pointing to asset bundles on a running DevServer instance, or else local file paths on disk.
+This library is designed to work either with assets generated via [`wp-scripts` build tooling](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/), or in conjunction with a JSON asset manifest file (such as those created with the presets in [@humanmade/webpack-helpers](https://github.com/humanmade/webpack-helpers)). This manifest associates asset bundle names with either URIs pointing to asset bundles on a running DevServer instance, or else local file paths on disk.
 
-### `Asset_Loader\register_asset()` and `Asset_Loader\enqueue_asset()`
+### `Asset_Loader\register_manifest_asset()` and `Asset_Loader\enqueue_manifest_asset()`
 
-`Asset_Loader` provides a set of methods for reading in this manifest file and registering a specific resource within it to load within your WordPress website. The primary public interface provided by this plugin is a pair of methods, `Asset_Loader\register_asset()` and `Asset_Loader\enqueue_asset()`. To register a manifest asset call one of these methods inside actions like `wp_enqueue_scripts` or `enqueue_block_editor_assets`, in the same manner you would have called the standard WordPress `wp_register_script` or `wp_enqueue_style` functions.
+`Asset_Loader` provides a set of methods for reading in this manifest file and registering a specific resource within it to load within your WordPress website. The primary public interface provided by this plugin is a pair of methods, `Asset_Loader\register_manifest_asset()` and `Asset_Loader\enqueue_manifest_asset()`. To register a manifest asset call one of these methods inside actions like `wp_enqueue_scripts` or `enqueue_block_editor_assets`, in the same manner you would have called the standard WordPress `wp_register_script` or `wp_enqueue_style` functions.
 
 ```php
 <?php
@@ -27,7 +27,7 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_edit
  * @return void
  */
 function enqueue_block_editor_assets() {
-  Asset_Loader\enqueue_asset(
+  Asset_Loader\enqueue_manifest_asset(
     // In a plugin, this would be `plugin_dir_path( __FILE__ )` or similar.
     get_stylesheet_directory() . '/build/asset-manifest.json',
     // The handle of a resource within the manifest. For static file fallbacks,
@@ -39,7 +39,7 @@ function enqueue_block_editor_assets() {
     ]
   );
 
-  Asset_Loader\enqueue_asset(
+  Asset_Loader\enqueue_manifest_asset(
     // In a plugin, this would be `plugin_dir_path( __FILE__ )` or similar.
     get_stylesheet_directory() . '/build/asset-manifest.json',
     // Enqueue CSS for the editor.
@@ -52,7 +52,7 @@ function enqueue_block_editor_assets() {
 }
 ```
 
-To register an asset to be manually enqueued later, use `Asset_Loader\register_asset()` instead of `enqueue_asset()`. Both methods take the same arguments.
+To register an asset to be manually enqueued later, use `Asset_Loader\register_manifest_asset()` instead of `enqueue_manifest_asset()`. Both methods take the same arguments.
 
 If a manifest is not present then `Asset_Loader` will attempt to load the specified resource from the same directory containing the manifest file.
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -30,12 +30,12 @@ function is_css( string $uri ): bool {
  * @return string
  */
 function _register_or_update_script( string $handle, string $asset_uri, array $dependencies, $version = false, $in_footer = true ): ?string {
-	// Handle the case where a `register_asset( 'foo.css' )` call falls back to
+	// Handle the case where a `register_manifest_asset( 'foo.css' )` call falls back to
 	// enqueue the dev bundle's JS. Since the dependencies provided in that CSS-
 	// specific registration call would not apply to the world of scripts, but
 	// a script asset would still get registered, we may need to update that new
 	// script's registration to reflect an actual list of JS dependencies if we
-	// later called `register_asset( 'foo.js' )`.
+	// later called `register_manifest_asset( 'foo.js' )`.
 	if ( ! empty( $dependencies ) ) {
 		$existing_scripts = wp_scripts();
 		if ( isset( $existing_scripts->registered[ $handle ]->deps ) ) {
@@ -67,7 +67,7 @@ function _register_or_update_script( string $handle, string $asset_uri, array $d
  * }
  * @return array Array detailing which script and/or style handles got registered.
  */
-function register_asset( ?string $manifest_path, string $target_asset, array $options = [] ): array {
+function register_manifest_asset( ?string $manifest_path, string $target_asset, array $options = [] ): array {
 	if ( empty( $manifest_path ) ) {
 		trigger_error( sprintf( 'No manifest specified when loading %s', esc_attr( $target_asset ) ), E_USER_NOTICE );
 		return [];
@@ -162,6 +162,25 @@ function register_asset( ?string $manifest_path, string $target_asset, array $op
 	return $handles;
 }
 
+
+/**
+ * Attempt to register a particular script bundle from a manifest.
+ *
+ * @deprecated 0.8.0 Use register_manifest_asset().
+ *
+ * @param ?string $manifest_path File system path for an asset manifest JSON file.
+ * @param string  $target_asset  Asset to retrieve within the specified manifest.
+ * @param array   $options {
+ *     @type string $handle       Handle to use when enqueuing the asset. Optional.
+ *     @type array  $dependencies Script or Style dependencies. Optional.
+ * }
+ * @return array Array detailing which script and/or style handles got registered.
+ */
+function register_asset( ?string $manifest_path, string $target_asset, array $options = [] ): array {
+	_deprecated_function( __FUNCTION__, '0.8.0', 'register_manifest_asset' );
+	return register_manifest_asset( $manifest_path, $target_asset, $options );
+}
+
 /**
  * Register and immediately enqueue a particular asset within a manifest.
  *
@@ -172,8 +191,8 @@ function register_asset( ?string $manifest_path, string $target_asset, array $op
  *     @type array  $dependencies Script or Style dependencies. Optional.
  * }
  */
-function enqueue_asset( ?string $manifest_path, string $target_asset, array $options = [] ): void {
-	$registered_handles = register_asset( $manifest_path, $target_asset, $options );
+function enqueue_manifest_asset( ?string $manifest_path, string $target_asset, array $options = [] ): void {
+	$registered_handles = register_manifest_asset( $manifest_path, $target_asset, $options );
 
 	if ( isset( $registered_handles['script'] ) ) {
 		wp_enqueue_script( $registered_handles['script'] );
@@ -181,4 +200,22 @@ function enqueue_asset( ?string $manifest_path, string $target_asset, array $opt
 	if ( isset( $registered_handles['style'] ) ) {
 		wp_enqueue_style( $registered_handles['style'] );
 	}
+}
+
+
+/**
+ * Attempt to enqueue a particular script bundle from a manifest.
+ *
+ * @deprecated 0.8.0 Use enqueue_manifest_asset().
+ *
+ * @param ?string $manifest_path File system path for an asset manifest JSON file.
+ * @param string  $target_asset  Asset to retrieve within the specified manifest.
+ * @param array   $options {
+ *     @type string $handle       Handle to use when enqueuing the asset. Optional.
+ *     @type array  $dependencies Script or Style dependencies. Optional.
+ * }
+ */
+function enqueue_asset( ?string $manifest_path, string $target_asset, array $options = [] ): void {
+	_deprecated_function( __FUNCTION__, '0.8.0', 'enqueue_manifest_asset' );
+	enqueue_manifest_asset( $manifest_path, $target_asset, $options );
 }

--- a/tests/inc/class-test-asset-loader.php
+++ b/tests/inc/class-test-asset-loader.php
@@ -111,23 +111,23 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 	}
 
 	/**
-	 * Test register_asset() behavior for script assets.
+	 * Test register_manifest_asset() behavior for script assets.
 	 *
 	 * @dataProvider provide_script_asset_cases
 	 */
 	public function test_register_script( string $manifest, string $resource, array $options, array $expected ): void {
-		Asset_Loader\register_asset( $this->{$manifest}, $resource, $options );
+		Asset_Loader\register_manifest_asset( $this->{$manifest}, $resource, $options );
 
 		$this->assertEquals( $expected, $this->scripts->get_registered( $expected['handle'] ) );
 	}
 
 	/**
-	 * Test enqueue_asset() behavior for script assets.
+	 * Test enqueue_manifest_asset() behavior for script assets.
 	 *
 	 * @dataProvider provide_script_asset_cases
 	 */
 	public function test_enqueue_script( string $manifest, string $resource, array $options, array $expected ): void {
-		Asset_Loader\enqueue_asset( $this->{$manifest}, $resource, $options );
+		Asset_Loader\enqueue_manifest_asset( $this->{$manifest}, $resource, $options );
 
 		$this->assertEquals( $expected, $this->scripts->get_registered( $expected['handle'] ) );
 		$this->assertEmpty( $this->styles->registered );
@@ -136,7 +136,7 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 	}
 
 	/**
-	 * Script test cases for register_asset and enqueue_asset.
+	 * Script test cases for register_manifest_asset and enqueue_manifest_asset.
 	 */
 	public function provide_script_asset_cases(): array {
 		return [
@@ -172,23 +172,23 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 	}
 
 	/**
-	 * Test register_asset() behavior for style assets.
+	 * Test register_manifest_asset() behavior for style assets.
 	 *
 	 * @dataProvider provide_style_asset_cases
 	 */
 	public function test_register_style( string $manifest, string $resource, array $options, array $expected ): void {
-		Asset_Loader\register_asset( $this->{$manifest}, $resource, $options );
+		Asset_Loader\register_manifest_asset( $this->{$manifest}, $resource, $options );
 
 		$this->assertEquals( $expected, $this->styles->get_registered( $expected['handle'] ) );
 	}
 
 	/**
-	 * Test enqueue_asset() behavior for style assets.
+	 * Test enqueue_manifest_asset() behavior for style assets.
 	 *
 	 * @dataProvider provide_style_asset_cases
 	 */
 	public function test_enqueue_style( string $manifest, string $resource, array $options, array $expected ): void {
-		Asset_Loader\enqueue_asset( $this->{$manifest}, $resource, $options );
+		Asset_Loader\enqueue_manifest_asset( $this->{$manifest}, $resource, $options );
 
 		$this->assertEquals( $expected, $this->styles->get_registered( $expected['handle'] ) );
 		$this->assertEmpty( $this->scripts->registered );
@@ -197,7 +197,7 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 	}
 
 	/**
-	 * Stylesheet test cases for register_asset and enqueue_asset.
+	 * Stylesheet test cases for register_manifest_asset and enqueue_manifest_asset.
 	 */
 	public function provide_style_asset_cases(): array {
 		return [
@@ -243,7 +243,7 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 	}
 
 	public function test_register_dev_stylesheet(): void {
-		Asset_Loader\register_asset(
+		Asset_Loader\register_manifest_asset(
 			$this->dev_manifest,
 			'frontend-styles.css',
 			[
@@ -263,7 +263,7 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 	}
 
 	public function test_enqueue_dev_stylesheet(): void {
-		Asset_Loader\enqueue_asset(
+		Asset_Loader\enqueue_manifest_asset(
 			$this->dev_manifest,
 			'frontend-styles.css',
 			[
@@ -285,7 +285,7 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 	}
 
 	public function test_register_dev_stylesheet_with_dependencies(): void {
-		Asset_Loader\register_asset(
+		Asset_Loader\register_manifest_asset(
 			$this->dev_manifest,
 			'frontend-styles.css',
 			[
@@ -314,7 +314,7 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 	}
 
 	public function test_enqueue_dev_stylesheet_with_dependencies(): void {
-		Asset_Loader\enqueue_asset(
+		Asset_Loader\enqueue_manifest_asset(
 			$this->dev_manifest,
 			'frontend-styles.css',
 			[
@@ -346,7 +346,7 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 	}
 
 	public function test_register_dev_stylesheet_then_corresponding_dev_script(): void {
-		Asset_Loader\register_asset(
+		Asset_Loader\register_manifest_asset(
 			$this->dev_manifest,
 			'editor.css',
 			[
@@ -354,7 +354,7 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 				'dependencies' => [ 'style-dependency' ],
 			]
 		);
-		Asset_Loader\register_asset(
+		Asset_Loader\register_manifest_asset(
 			$this->dev_manifest,
 			'editor.js',
 			[
@@ -383,7 +383,7 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 	}
 
 	public function test_enqueue_dev_stylesheet_then_corresponding_dev_script(): void {
-		Asset_Loader\enqueue_asset(
+		Asset_Loader\enqueue_manifest_asset(
 			$this->dev_manifest,
 			'editor.css',
 			[
@@ -391,7 +391,7 @@ class Test_Asset_Loader extends Asset_Loader_Test_Case {
 				'dependencies' => [ 'style-dependency' ],
 			]
 		);
-		Asset_Loader\enqueue_asset(
+		Asset_Loader\enqueue_manifest_asset(
 			$this->dev_manifest,
 			'editor.js',
 			[


### PR DESCRIPTION
This will set us up to maintain existing APIs for asset manifest JSON loading, but also introduce new more targeted methods for compatibility with a WP-Scripts build as part of 1.0.