### PR TITLE
Add register_block_extension method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.0
 
 - Introduce `wp-scripts`-oriented `register_script_asset()` and `enqueue_script_asset()` functions. [#78](https://github.com/humanmade/asset-loader/pull/78)
+- Introduce `register_core_block_extension()` to extend existing block types with additional scripts and styles via a block.json file entrypoint. [#79](https://github.com/humanmade/asset-loader/pull/79)
 
 ## v0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.0.0
 
 - Introduce `wp-scripts`-oriented `register_script_asset()` and `enqueue_script_asset()` functions. [#78](https://github.com/humanmade/asset-loader/pull/78)
-- Introduce `register_core_block_extension()` to extend existing block types with additional scripts and styles via a block.json file entrypoint. [#79](https://github.com/humanmade/asset-loader/pull/79)
+- Introduce `register_block_extension()` to extend existing block types with additional scripts and styles via a block.json file entrypoint. [#79](https://github.com/humanmade/asset-loader/pull/79)
 
 ## v0.8.0
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ function enqueue_block_editor_assets() {
 }
 ```
 
+### Block Extensions API
+
+Use `register_core_block_extension()` to attach additional scripts and styles to an already-registered block type (core or third-party) via a `block.json` file, without registering a new block.
+
+```php
+<?php
+use Asset_Loader;
+
+add_action( 'init', function() {
+    // Extend core/paragraph with a custom viewScript and style.
+    // The block.json at this path should have "name": "core/paragraph"
+    // and declare assets using file:./relative paths.
+    Asset_Loader\register_core_block_extension(
+        plugin_dir_path( __FILE__ ) . 'build/blocks/core/paragraph/block.json'
+    );
+} );
+```
+
 ## Documentation
 
 For complete documentation, including contributing process, visit the [docs site](https://humanmade.github.io/asset-loader/).

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ function enqueue_block_editor_assets() {
 
 ### Block Extensions API
 
-Use `register_core_block_extension()` to attach additional scripts and styles to an already-registered block type (core or third-party) via a `block.json` file, without registering a new block.
+Use `register_block_extension()` to attach additional scripts and styles to an already-registered block type (core or third-party) via a `block.json` file, without registering a new block.
 
 ```php
 <?php
@@ -93,7 +93,7 @@ add_action( 'init', function() {
     // Extend core/paragraph with a custom viewScript and style.
     // The block.json at this path should have "name": "core/paragraph"
     // and declare assets using file:./relative paths.
-    Asset_Loader\register_core_block_extension(
+    Asset_Loader\register_block_extension(
         plugin_dir_path( __FILE__ ) . 'build/blocks/core/paragraph/block.json'
     );
 } );

--- a/docs/02-usage.md
+++ b/docs/02-usage.md
@@ -9,9 +9,9 @@ permalink: /usage
 
 Asset Loader provides two complementary APIs for loading bundled assets in WordPress:
 
-1. **Script Asset API** (`register_script_asset` / `enqueue_script_asset`) — The primary public interface, designed for scripts built with [`wp-scripts`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/). Use these functions when your build outputs `.asset.php` dependency files alongside each bundle.
+1. **Script Asset API** (`register_script_asset` / `enqueue_script_asset`): The primary public interface, designed for scripts built with [`wp-scripts`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/). Use these functions when your build outputs `.asset.php` dependency files alongside each bundle.
 
-2. **Manifest Asset API** (`register_manifest_asset` / `enqueue_manifest_asset`) — For custom Webpack configurations that output a JSON asset manifest, such as those created with [@humanmade/webpack-helpers](https://github.com/humanmade/webpack-helpers).
+2. **Manifest Asset API** (`register_manifest_asset` / `enqueue_manifest_asset`): For custom Webpack configurations that output a JSON asset manifest, such as those created with [@humanmade/webpack-helpers](https://github.com/humanmade/webpack-helpers).
 
 ## Script Asset API
 
@@ -35,9 +35,9 @@ Asset_Loader\register_script_asset(
 
 **Parameters:**
 
-- **`$handle`** _(string)_ — The handle to register the script under.
-- **`$asset_path`** _(string)_ — The absolute file system path to the built `.js` file. A corresponding `.asset.php` file must exist at the same location (e.g., `build/index.js` → `build/index.asset.php`).
-- **`$additional_deps`** _(string[], optional)_ — Additional script handles to merge into the auto-detected dependency list from the `.asset.php` file.
+- **`$handle`** _(string)_: The handle to register the script under.
+- **`$asset_path`** _(string)_: The absolute file system path to the built `.js` file. A corresponding `.asset.php` file must exist at the same location (e.g., `build/index.js` → `build/index.asset.php`).
+- **`$additional_deps`** _(string[], optional)_: Additional script handles to merge into the auto-detected dependency list from the `.asset.php` file.
 
 ### `Asset_Loader\enqueue_script_asset()`
 
@@ -113,12 +113,12 @@ Asset_Loader\enqueue_manifest_asset(
 
 **Parameters:**
 
-- **`$manifest_path`** _(string|string[])_ — File system path to an `asset-manifest.json` file, or an array of paths (the first readable manifest will be used).
-- **`$target_asset`** _(string)_ — The bundle name to look up in the manifest (e.g. `'editor.js'`).
+- **`$manifest_path`** _(string|string[])_: File system path to an `asset-manifest.json` file, or an array of paths (the first readable manifest will be used).
+- **`$target_asset`** _(string)_: The bundle name to look up in the manifest (e.g. `'editor.js'`).
 - **`$options`** _(array, optional)_:
-  - `handle` _(string)_ — Custom handle for the registered asset. Defaults to `$target_asset`.
-  - `dependencies` _(string[])_ — Script or style dependencies.
-  - `in-footer` _(bool)_ — Whether to load in the footer. Defaults to `true`.
+  - `handle` _(string)_: Custom handle for the registered asset. Defaults to `$target_asset`.
+  - `dependencies` _(string[])_: Script or style dependencies.
+  - `in-footer` _(bool)_: Whether to load in the footer. Defaults to `true`.
 
 ### Example
 
@@ -169,7 +169,7 @@ By default, all enqueues will be added at the end of the page, in the `wp_footer
 
 ## Block Extensions API
 
-Use `register_core_block_extension()` to attach additional scripts and styles to an already-registered block type. This is useful when you need to augment a core or third-party block with your own assets — for example, adding a `viewScript` to `core/paragraph` or an `editorScript` to `core/image` — without registering a new block.
+Use `register_core_block_extension()` to attach additional scripts and styles to an already-registered block type. This is useful when you need to augment a core or third-party block with your own assets (_e.g._ adding a `viewScript` to `core/paragraph` or an `editorScript` to `core/image`) without registering a new block.
 
 Write a standard `block.json` whose `name` field references the block you want to extend, and declare any combination of `editorScript`, `script`, `viewScript`, `editorStyle`, and `style` fields using `file:./` relative paths as you would for a normal block. Then call `register_core_block_extension()` with the path to that file.
 
@@ -185,7 +185,7 @@ Asset_Loader\register_core_block_extension(
 
 **Parameters:**
 
-- **`$block_json_path`** _(string)_ — Absolute file system path to a `block.json` file. The file must contain a `name` field identifying the target block, and one or more asset fields (`editorScript`, `script`, `viewScript`, `editorStyle`, `style`) with `file:./` relative paths.
+- **`$block_json_path`** _(string)_: Absolute file system path to a `block.json` file. The file must contain a `name` field identifying the target block, and one or more asset fields (`editorScript`, `script`, `viewScript`, `editorStyle`, `style`) with `file:./` relative paths.
 
 ### Example
 
@@ -229,5 +229,5 @@ function register_block_extensions() {
 
 WordPress will now automatically enqueue `view.js` and `style.css` whenever a `core/paragraph` block is rendered, without registering a new block type.
 
-This works for any registered block — not just core blocks.
+This interface was designed specifically to easily extend core blocks, but it will work for any registered third-party block.
 

--- a/docs/02-usage.md
+++ b/docs/02-usage.md
@@ -169,16 +169,16 @@ By default, all enqueues will be added at the end of the page, in the `wp_footer
 
 ## Block Extensions API
 
-Use `register_core_block_extension()` to attach additional scripts and styles to an already-registered block type. This is useful when you need to augment a core or third-party block with your own assets (_e.g._ adding a `viewScript` to `core/paragraph` or an `editorScript` to `core/image`) without registering a new block.
+Use `register_block_extension()` to attach additional scripts and styles to an already-registered block type. This is useful when you need to augment a core or third-party block with your own assets (_e.g._ adding a `viewScript` to `core/paragraph` or an `editorScript` to `core/image`) without registering a new block.
 
-Write a standard `block.json` whose `name` field references the block you want to extend, and declare any combination of `editorScript`, `script`, `viewScript`, `editorStyle`, and `style` fields using `file:./` relative paths as you would for a normal block. Then call `register_core_block_extension()` with the path to that file.
+Write a standard `block.json` whose `name` field references the block you want to extend, and declare any combination of `editorScript`, `script`, `viewScript`, `editorStyle`, and `style` fields using `file:./` relative paths as you would for a normal block. Then call `register_block_extension()` with the path to that file.
 
-Extensions are processed on `wp_loaded`, after all blocks have been registered. You can call `register_core_block_extension()` at any point up through `wp_loaded`.
+Extensions are processed on `wp_loaded`, after all blocks have been registered. You can call `register_block_extension()` at any point up through `wp_loaded`.
 
-### `Asset_Loader\register_core_block_extension()`
+### `Asset_Loader\register_block_extension()`
 
 ```php
-Asset_Loader\register_core_block_extension(
+Asset_Loader\register_block_extension(
     string $block_json_path
 );
 ```
@@ -221,7 +221,7 @@ use Asset_Loader;
 add_action( 'init', __NAMESPACE__ . '\\register_block_extensions' );
 
 function register_block_extensions() {
-    Asset_Loader\register_core_block_extension(
+    Asset_Loader\register_block_extension(
         plugin_dir_path( __DIR__ ) . 'build/blocks/core/paragraph/block.json'
     );
 }

--- a/docs/02-usage.md
+++ b/docs/02-usage.md
@@ -231,3 +231,19 @@ WordPress will now automatically enqueue `view.js` and `style.css` whenever a `c
 
 This interface was designed specifically to easily extend core blocks, but it will work for any registered third-party block.
 
+### Skipping enqueue for stub scripts
+
+Some `wp-scripts` builds require a JavaScript entry point to produce a CSS output file, even when there is no meaningful JS to run on the page. In this situation a `block.json` may declare a script field solely to trigger the CSS build, but you don't want that stub JS file to be enqueued at runtime.
+
+Append `?skip_enqueue` to the asset path to opt it out of enqueue processing:
+
+```json
+{
+    "name": "core/paragraph",
+    "editorScript": "file:./index.js?skip_enqueue",
+    "style": "file:./style.css"
+}
+```
+
+When `register_block_extension()` encounters a script or style path containing `?skip_enqueue`, it silently skips that entry instead of registering and enqueuing it. The build tooling still sees a valid entry point, so the CSS file is generated as expected.
+

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -365,14 +365,10 @@ function register_block_extension( string $block_json_path ): void {
 	$block_config['file'] = wp_normalize_path( realpath( $block_json_path ) );
 
 	if ( did_action( 'wp_loaded' ) ) {
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions
-		trigger_error(
-			'register_block_extension() must be called before the wp_loaded hook',
-			E_USER_NOTICE
-		);
-	}
-
-	add_action( 'wp_loaded', function () use ( $target_block, $block_config ) {
 		Utilities\apply_block_extension( $target_block, $block_config );
-	} );
+	} else {
+		add_action( 'wp_loaded', function () use ( $target_block, $block_config ) {
+			Utilities\apply_block_extension( $target_block, $block_config );
+		} );
+	}
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -334,9 +334,6 @@ function enqueue_script_asset( string $handle, string $asset_path, array $additi
  * @param string $block_json_path Absolute file system path to a block.json file.
  */
 function register_block_extension( string $block_json_path ): void {
-	static $extensions = [];
-	static $hooked = false;
-
 	if ( ! is_readable( $block_json_path ) ) {
 		if ( wp_get_environment_type() === 'local' ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions
@@ -367,19 +364,15 @@ function register_block_extension( string $block_json_path ): void {
 	// register_block_style_handle() can resolve relative asset paths.
 	$block_config['file'] = wp_normalize_path( realpath( $block_json_path ) );
 
-	$extensions[ $target_block ][] = $block_config;
-
-	if ( ! $hooked ) {
-		$hooked = true;
-		if ( did_action( 'wp_loaded' ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions
-			trigger_error(
-				'register_block_extension() must be called before the wp_loaded hook',
-				E_USER_NOTICE
-			);
-		}
-		add_action( 'wp_loaded', function () use ( &$extensions ) {
-			Utilities\apply_block_extensions( $extensions );
-		} );
+	if ( did_action( 'wp_loaded' ) ) {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions
+		trigger_error(
+			'register_block_extension() must be called before the wp_loaded hook',
+			E_USER_NOTICE
+		);
 	}
+
+	add_action( 'wp_loaded', function () use ( $target_block, $block_config ) {
+		Utilities\apply_block_extension( $target_block, $block_config );
+	} );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -371,6 +371,13 @@ function register_core_block_extension( string $block_json_path ): void {
 
 	if ( ! $hooked ) {
 		$hooked = true;
+		if ( did_action( 'wp_loaded' ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions
+			trigger_error(
+				'register_core_block_extension() must be called before the wp_loaded hook',
+				E_USER_NOTICE
+			);
+		}
 		add_action( 'wp_loaded', function () use ( &$extensions ) {
 			Utilities\apply_block_extensions( $extensions );
 		} );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -326,14 +326,14 @@ function enqueue_script_asset( string $handle, string $asset_path, array $additi
  * those assets whenever the target block is used, without registering a new
  * block type.
  *
- * Works for any registered block, not just core blocks.
+ * Works for core blocks or any registered third-party block.
  *
  * Extensions are applied on `wp_loaded` (after all blocks have been registered).
- * Can be called at any point up through `wp_loaded`.
+ * Can be called at any point up through `wp_loaded`, but `init` is recommended.
  *
  * @param string $block_json_path Absolute file system path to a block.json file.
  */
-function register_core_block_extension( string $block_json_path ): void {
+function register_block_extension( string $block_json_path ): void {
 	static $extensions = [];
 	static $hooked = false;
 
@@ -374,7 +374,7 @@ function register_core_block_extension( string $block_json_path ): void {
 		if ( did_action( 'wp_loaded' ) ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions
 			trigger_error(
-				'register_core_block_extension() must be called before the wp_loaded hook',
+				'register_block_extension() must be called before the wp_loaded hook',
 				E_USER_NOTICE
 			);
 		}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -326,7 +326,7 @@ function enqueue_script_asset( string $handle, string $asset_path, array $additi
  * those assets whenever the target block is used, without registering a new
  * block type.
  *
- * Works for any registered block — not just core blocks.
+ * Works for any registered block, not just core blocks.
  *
  * Extensions are applied on `wp_loaded` (after all blocks have been registered).
  * Can be called at any point up through `wp_loaded`.

--- a/inc/utilities.php
+++ b/inc/utilities.php
@@ -235,6 +235,12 @@ function apply_block_extension( string $block_name, array $block_extension ): vo
 		$type = strpos( strtolower( $field ), 'script' ) !== false ? 'script' : 'style';
 
 		foreach ( (array) $block_extension[ $field ] as $index => $asset ) {
+			// Allow scripts that only exist to trigger a CSS build to self-exclude
+			// with a query string, "file:./index.js?skip_enqueue"
+			if ( strpos( $asset, '?skip_enqueue' ) > 0 ) {
+				continue;
+			}
+
 			$meta_for_registration           = $block_extension;
 			$meta_for_registration[ $field ] = $asset;
 

--- a/inc/utilities.php
+++ b/inc/utilities.php
@@ -222,7 +222,7 @@ function apply_block_extension( string $block_name, array $block_extension ): vo
 		return;
 	}
 
-	$asset_fields  = [ 'editorScript', 'script', 'viewScript', 'editorStyle', 'style', 'viewStyle' ];
+	$asset_fields = [ 'editorScript', 'script', 'viewScript', 'editorStyle', 'style', 'viewStyle' ];
 
 	foreach ( $asset_fields as $field ) {
 		if ( ! isset( $block_extension[ $field ] ) ) {

--- a/inc/utilities.php
+++ b/inc/utilities.php
@@ -178,3 +178,85 @@ function show_local_frontend_debug_mode_warning(): void {
 	</div>
 	<?php
 }
+
+/**
+ * Map a block.json asset field name to its corresponding WP_Block_Type
+ * handles property.
+ *
+ * @param string $field A block.json asset field (e.g. 'editorScript', 'style').
+ * @return string The WP_Block_Type property name (e.g. 'editor_script_handles').
+ */
+function get_block_handles_property( string $field ): string {
+	$map = [
+		'editorScript' => 'editor_script_handles',
+		'script'       => 'script_handles',
+		'viewScript'   => 'view_script_handles',
+		'editorStyle'  => 'editor_style_handles',
+		'style'        => 'style_handles',
+	];
+	return $map[ $field ] ?? '';
+}
+
+/**
+ * Process registered block extensions by merging their assets into already-
+ * registered block types.
+ *
+ * For each extension, uses WP core's register_block_script_handle() and
+ * register_block_style_handle() to register the extension's assets, then
+ * appends the resulting handles to the target block type's handle arrays.
+ *
+ * @param array $extensions Map of block name => array of extension block.json configs.
+ */
+function apply_block_extensions( array $extensions ): void {
+	$registry = \WP_Block_Type_Registry::get_instance();
+
+	$script_fields = [ 'editorScript', 'script', 'viewScript' ];
+	$style_fields  = [ 'editorStyle', 'style' ];
+
+	foreach ( $extensions as $block_name => $block_extensions ) {
+		$block_type = $registry->get_registered( $block_name );
+		if ( ! $block_type ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions
+			trigger_error(
+				sprintf( 'Block type "%s" is not registered; cannot apply extension.', esc_attr( $block_name ) ),
+				E_USER_WARNING
+			);
+			continue;
+		}
+
+		foreach ( $block_extensions as $extension ) {
+			// Merge script assets.
+			foreach ( $script_fields as $field ) {
+				if ( ! isset( $extension[ $field ] ) ) {
+					continue;
+				}
+				$handles_prop = get_block_handles_property( $field );
+				foreach ( (array) $extension[ $field ] as $index => $script ) {
+					$meta_for_registration           = $extension;
+					$meta_for_registration[ $field ] = $script;
+					// Use a high index to avoid handle collisions with the target block.
+					$handle = register_block_script_handle( $meta_for_registration, $field, $index + 100 );
+					if ( $handle && ! in_array( $handle, $block_type->$handles_prop, true ) ) {
+						$block_type->$handles_prop[] = $handle;
+					}
+				}
+			}
+
+			// Merge style assets.
+			foreach ( $style_fields as $field ) {
+				if ( ! isset( $extension[ $field ] ) ) {
+					continue;
+				}
+				$handles_prop = get_block_handles_property( $field );
+				foreach ( (array) $extension[ $field ] as $index => $style ) {
+					$meta_for_registration           = $extension;
+					$meta_for_registration[ $field ] = $style;
+					$handle = register_block_style_handle( $meta_for_registration, $field, $index + 100 );
+					if ( $handle && ! in_array( $handle, $block_type->$handles_prop, true ) ) {
+						$block_type->$handles_prop[] = $handle;
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Recreated from #79 after I made a mistake with branch naming.

This implements the concept behind a piece of wp-scripts-asset-loader without being as prescriptive about file organization as that plugin.

If you pass a block.json specifying a `name` handle (e.g. core/paragraph) and one or more script or style references, like `"style": "file:./style.css"` to the new `register_core_block_extension` method, it will merge this into the core paragraph's dependencies and enqueue that style on output.

**Open question:** Looking for feedback on the point at which we recommend calling this method, and the hook on which we step in and modify the core scripts. It works most-reliably on init (when core registers its blocks), but can technically be run any time before core processes and outputs its own block scripts.