### PR TITLE
Prepare 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.0.0
 
 - Introduce `wp-scripts`-oriented `register_script_asset()` and `enqueue_script_asset()` functions. [#78](https://github.com/humanmade/asset-loader/pull/78)
-- Introduce `register_block_extension()` to extend existing block types with additional scripts and styles via a block.json file entrypoint. [#79](https://github.com/humanmade/asset-loader/pull/79)
+- Introduce `register_block_extension()` to extend existing block types with additional scripts and styles via a block.json file entrypoint. [#80](https://github.com/humanmade/asset-loader/pull/80)
 
 ## v0.8.0
 

--- a/asset-loader.php
+++ b/asset-loader.php
@@ -13,7 +13,7 @@
  * Plugin Name: Asset Loader
  * Plugin URI:  https://github.com/humanmade/asset-loader
  * Description: Utilities to seamlessly consume Webpack-bundled assets in WordPress themes & plugins.
- * Version:     0.8.0
+ * Version:     1.0.0
  * Author:      K Adam White
  * Author URI:  http://kadamwhite.com
  * License:     GPL-2.0+


### PR DESCRIPTION
Our new APIs have been working well in client projects running off of prerelease branches; I propose we tag 1.0 to enable the plugin to move forward predictably.

> [!NOTE]
> This deliberately doesn't remove the deprecated methods, in order to permit projects to update to 1.0 for both APIs if needed. I'm open to feedback on whether that's a bad idea and we should drop the deprecated methods now.