### PR TITLE
PHPCS: Use braces to qualify order of access

### DIFF
--- a/inc/utilities.php
+++ b/inc/utilities.php
@@ -250,7 +250,7 @@ function apply_block_extension( string $block_name, array $block_extension ): vo
 				: register_block_style_handle( $meta_for_registration, $field, $index + 100 );
 
 			if ( $handle && ! in_array( $handle, $block_type->$handles_prop, true ) ) {
-				$block_type->$handles_prop[] = $handle;
+				$block_type->{$handles_prop}[] = $handle;
 			}
 		}
 	}


### PR DESCRIPTION
This resolves a PHPCS warning, "Indirect access to variables, properties and methods will be evaluated strictly in left-to-right order since PHP 7.0. Use curly braces to remove ambiguity."